### PR TITLE
Move to 2.5 payload URL

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -289,7 +289,7 @@ int main() {
           //Download Payload
           httpcContext context;
           static char url[512]; //Build URL for Payload
-          sprintf(url, "http://smealum.github.io/ninjhax2/Pvl9iD2Im5/otherapp/%s.bin", payload_name);
+          sprintf(url, "http://smealum.github.io/ninjhax2/JL1Xf2KFVm/otherapp/%s.bin", payload_name);
 
           sprintf(status, "Downloading payload %s", payload_name);
           Result ret = httpcOpenContext(&context, url, 0);


### PR DESCRIPTION
It seems the old 2.1 otherapp payloads are no longer available—anything under http://smealum.github.io/ninjhax2/Pvl9iD2Im5/otherapp/ returns a 404 now. The 2.5 payloads are at a different address, so the URL needs to be changed. (Note that I haven't recompiled the binaries, but this really should work.)

Incidentally, the 2.5 payloads are also larger by a few KB, so I believe OoT3D save data can barely hold the payload plus the exploit save file now.
